### PR TITLE
Kafka logger multi log split

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,9 +272,7 @@ lint:
 
 # Run all tests
 test:
-	go clean -testcache ./...
-	go test ./utils -v
-	go test ./cmd/tls/handlers -v
+	go test ./...
 
 # Check test coverage
 test_cover:

--- a/pkg/logging/kafka.go
+++ b/pkg/logging/kafka.go
@@ -17,10 +17,14 @@ import (
 	"github.com/twmb/tlscfg"
 )
 
+type KafkaProducer interface {
+	ProduceSync(ctx context.Context, records ...*kgo.Record) kgo.ProduceResults
+}
+
 type LoggerKafka struct {
 	config   config.KafkaConfiguration
 	Enabled  bool
-	producer *kgo.Client
+	producer KafkaProducer
 }
 
 func CreateLoggerKafka(config config.KafkaConfiguration) (*LoggerKafka, error) {

--- a/pkg/logging/kafka.go
+++ b/pkg/logging/kafka.go
@@ -2,11 +2,13 @@ package logging
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 
 	"github.com/jmpsec/osctrl/pkg/config"
 	"github.com/jmpsec/osctrl/pkg/settings"
+	"github.com/jmpsec/osctrl/pkg/types"
 
 	"github.com/rs/zerolog/log"
 	"github.com/twmb/franz-go/pkg/kgo"
@@ -85,6 +87,25 @@ func (l *LoggerKafka) Settings(mgr *settings.Settings) {
 	log.Warn().Msg("No kafka logging settings")
 }
 
+func (l *LoggerKafka) parseLogs(logType string, data []byte) ([]any, error) {
+	// QueryLogs = distributed query results are delivered from OSQuery as a single JSON object.
+	if logType == types.QueryLog {
+		var result any
+		if err := json.Unmarshal(data, &result); err != nil {
+			return nil, fmt.Errorf("error parsing data %s: %w", string(data), err)
+		}
+		return []any{result}, nil
+	}
+
+	// others (Result + Status) are delivered in an array
+	var logs []any
+	if err := json.Unmarshal(data, &logs); err != nil {
+		return nil, fmt.Errorf("error parsing log %s: %w", string(data), err)
+	}
+
+	return logs, nil
+}
+
 func (l *LoggerKafka) Send(logType string, data []byte, environment, uuid string, debug bool) {
 	if debug {
 		log.Info().Msgf(
@@ -92,19 +113,38 @@ func (l *LoggerKafka) Send(logType string, data []byte, environment, uuid string
 			len(data), l.config.Topic, environment, uuid)
 	}
 
+	logs, err := l.parseLogs(logType, data)
+	if err != nil {
+		log.Err(err).Msg("failed to parse logs")
+		return
+	}
+
 	ctx := context.Background()
 	key := []byte(uuid) // uuid is the unique id of the os-query agent host that sent this data
-	rec := kgo.Record{Topic: l.config.Topic, Key: key, Value: data}
-	l.producer.Produce(ctx, &rec, func(r *kgo.Record, err error) {
+
+	// Prepare all kafka records, so they can be sent in one batch
+	var records []*kgo.Record
+	for _, logEntry := range logs {
+		jsonEvent, err := json.Marshal(logEntry)
 		if err != nil {
-			log.Info().Msgf(
-				"failed to produce message to kafka topic '%s'. details: %s",
-				l.config.Topic, err)
+			log.Err(err).Msg("Error parsing data")
+			continue
 		}
-		if debug {
-			log.Info().Msgf(
-				"message with key '%s' was sent to topic '%s' successfully\n%s",
-				key, l.config.Topic, string(data))
-		}
-	})
+
+		r := &kgo.Record{Topic: l.config.Topic, Key: key, Value: jsonEvent}
+		records = append(records, r)
+	}
+
+	if len(records) == 0 {
+		log.Warn().Msgf("unexpected record count of 0 from %s:%s", uuid, environment)
+		return
+	}
+
+	results := l.producer.ProduceSync(ctx, records...)
+	if err := results.FirstErr(); err != nil {
+		log.Err(err).Msgf("failed to produce messages to kafka topic '%s'", l.config.Topic)
+	} else if debug {
+		log.Info().Msgf("successfully sent %d %s messages to kafka topic '%s' from %s:%s",
+			len(records), logType, l.config.Topic, uuid, environment)
+	}
 }

--- a/pkg/logging/kafka_test.go
+++ b/pkg/logging/kafka_test.go
@@ -1,0 +1,181 @@
+package logging
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/jmpsec/osctrl/pkg/config"
+	"github.com/jmpsec/osctrl/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/kgo"
+)
+
+type MockKafkaProducer struct {
+	SentRecords []*kgo.Record
+	Results     kgo.ProduceResults
+}
+
+func CreateTestableLoggerKafka(config config.KafkaConfiguration, mockProducer KafkaProducer) *LoggerKafka {
+	return &LoggerKafka{
+		config:   config,
+		Enabled:  true,
+		producer: mockProducer,
+	}
+}
+
+func (m *MockKafkaProducer) ProduceSync(ctx context.Context, records ...*kgo.Record) kgo.ProduceResults {
+	m.SentRecords = append(m.SentRecords, records...)
+	return m.Results
+}
+
+func (m *MockKafkaProducer) GetSentValues() [][]byte {
+	values := make([][]byte, len(m.SentRecords))
+	for i, record := range m.SentRecords {
+		values[i] = record.Value
+	}
+	return values
+}
+
+func (m *MockKafkaProducer) GetSentKeys() [][]byte {
+	keys := make([][]byte, len(m.SentRecords))
+	for i, record := range m.SentRecords {
+		keys[i] = record.Key
+	}
+	return keys
+}
+
+func (m *MockKafkaProducer) GetSentTopics() []string {
+	topics := make([]string, len(m.SentRecords))
+	for i, record := range m.SentRecords {
+		topics[i] = record.Topic
+	}
+	return topics
+}
+
+func TestLoggerKafka_Send_QueryLog(t *testing.T) {
+	mockProducer := &MockKafkaProducer{}
+
+	logger := CreateTestableLoggerKafka(config.KafkaConfiguration{
+		Topic: "test-topic",
+	}, mockProducer)
+
+	queryData := map[string]interface{}{
+		"query":  "SELECT * FROM processes",
+		"status": 0,
+		"results": []map[string]interface{}{
+			{"pid": "1234", "name": "test-process"},
+		},
+	}
+	queryJSON, err := json.Marshal(queryData)
+	require.NoError(t, err)
+
+	logger.Send(types.QueryLog, queryJSON, "test-env", "test-uuid", false)
+
+	// Verify exactly 1 record was sent
+	assert.Len(t, mockProducer.SentRecords, 1, "QueryLog should produce exactly 1 Kafka record")
+
+	// Verify record content
+	record := mockProducer.SentRecords[0]
+	assert.Equal(t, "test-topic", record.Topic)
+	assert.Equal(t, []byte("test-uuid"), record.Key)
+
+	// Verify the value contains the complete query data
+	var sentData map[string]interface{}
+	err = json.Unmarshal(record.Value, &sentData)
+	require.NoError(t, err)
+	assert.Equal(t, "SELECT * FROM processes", sentData["query"])
+	assert.Equal(t, float64(0), sentData["status"])
+}
+
+func TestLoggerKafka_Send_ResultLog_MultipleSplit(t *testing.T) {
+	mockProducer := &MockKafkaProducer{}
+
+	logger := CreateTestableLoggerKafka(config.KafkaConfiguration{
+		Topic: "test-topic",
+	}, mockProducer)
+
+	resultData := []map[string]interface{}{
+		{"pid": "1234", "name": "process1", "cpu_time": "100"},
+		{"pid": "5678", "name": "process2", "cpu_time": "200"},
+		{"pid": "9012", "name": "process3", "cpu_time": "300"},
+	}
+	resultJSON, err := json.Marshal(resultData)
+	require.NoError(t, err)
+
+	logger.Send(types.ResultLog, resultJSON, "test-env", "test-uuid", false)
+
+	// Verify 3 separate records were sent
+	assert.Len(t, mockProducer.SentRecords, 3, "ResultLog array should produce 3 separate Kafka records")
+
+	// Verify each record
+	expectedData := []map[string]interface{}{
+		{"pid": "1234", "name": "process1", "cpu_time": "100"},
+		{"pid": "5678", "name": "process2", "cpu_time": "200"},
+		{"pid": "9012", "name": "process3", "cpu_time": "300"},
+	}
+
+	for i, record := range mockProducer.SentRecords {
+		// Verify topic and key are consistent
+		assert.Equal(t, "test-topic", record.Topic)
+		assert.Equal(t, []byte("test-uuid"), record.Key)
+
+		// Verify each record contains the expected individual entry
+		var sentData map[string]interface{}
+		err = json.Unmarshal(record.Value, &sentData)
+		require.NoError(t, err)
+
+		assert.Equal(t, expectedData[i]["pid"], sentData["pid"])
+		assert.Equal(t, expectedData[i]["name"], sentData["name"])
+		assert.Equal(t, expectedData[i]["cpu_time"], sentData["cpu_time"])
+	}
+}
+
+func TestLoggerKafka_Send_StatusLog_MultipleSplit(t *testing.T) {
+	mockProducer := &MockKafkaProducer{}
+
+	logger := CreateTestableLoggerKafka(config.KafkaConfiguration{
+		Topic: "status-topic",
+	}, mockProducer)
+
+	// Test data - multiple status entries
+	statusData := []map[string]interface{}{
+		{"severity": "INFO", "message": "Query executed successfully"},
+		{"severity": "WARNING", "message": "Config file outdated"},
+	}
+	statusJSON, err := json.Marshal(statusData)
+	require.NoError(t, err)
+
+	logger.Send(types.StatusLog, statusJSON, "prod-env", "host-123", true) // debug=true
+
+	// Verify 2 separate records were sent
+	assert.Len(t, mockProducer.SentRecords, 2, "StatusLog should produce 2 separate Kafka records")
+
+	// Verify topics are all correct
+	topics := mockProducer.GetSentTopics()
+	for _, topic := range topics {
+		assert.Equal(t, "status-topic", topic)
+	}
+
+	// Verify keys are all the same
+	keys := mockProducer.GetSentKeys()
+	for _, key := range keys {
+		assert.Equal(t, []byte("host-123"), key)
+	}
+
+	// Verify individual message content
+	values := mockProducer.GetSentValues()
+
+	var firstMessage map[string]interface{}
+	err = json.Unmarshal(values[0], &firstMessage)
+	require.NoError(t, err)
+	assert.Equal(t, "INFO", firstMessage["severity"])
+	assert.Equal(t, "Query executed successfully", firstMessage["message"])
+
+	var secondMessage map[string]interface{}
+	err = json.Unmarshal(values[1], &secondMessage)
+	require.NoError(t, err)
+	assert.Equal(t, "WARNING", secondMessage["severity"])
+	assert.Equal(t, "Config file outdated", secondMessage["message"])
+}


### PR DESCRIPTION
This PR changes how the Kafka logger works, by ensuring that all logs received from OSQuery are split into individual logs before producing them to Kafka.

There is still only one request made to the kafka broker, however logs from OSQuery are split into separate messages before the send.